### PR TITLE
Add k6 load and repository benchmarks

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,76 @@
+# Performance Benchmarks
+
+This folder contains two complementary benchmarking tools:
+
+1. A **k6 load test** that exercises every public HTTP endpoint and reports throughput
+   metrics such as RPS (requests per second) and RPM (requests per minute).
+2. A **database query benchmark** that measures how fast each repository method runs so
+   you can estimate internal query throughput.
+
+Both tools assume the API server is already running and that the database contains the
+lookup rows required by the application. They automatically provision a synthetic test
+user if one does not exist so they can authenticate safely.
+
+## k6 endpoint benchmark
+
+Run the load test against a running server (default `http://localhost:5000`):
+
+```bash
+k6 run performance/k6/performance.test.js
+```
+
+Environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BASE_URL` | `http://localhost:5000` | Base URL of the API under test. |
+| `AUTH_EMAIL` | auto-generated | Email for the synthetic load-test user. Existing credentials are reused when provided. |
+| `AUTH_PASSWORD` | `PerfTest@123` | Password for the synthetic user (used when creating or logging in). |
+| `AUTH_USERNAME` | derived from email | Username for the synthetic user. |
+| `TARGET_RPS` | `5` | Target arrival rate (requests per second) for each scenario. |
+| `TEST_DURATION` | `1m` | Duration of each scenario. |
+| `PRE_ALLOCATED_VUS` | `20` | Pre-allocated virtual users for the constant-arrival executor. |
+| `ENABLE_WRITE_SCENARIOS` | `true` | Set to `false` to skip write-heavy endpoints (progress updates, form submissions). |
+| `SESSION_COOKIE_NAME` | `rota_session` | Override the session cookie name if your deployment customises it. |
+| `CSRF_COOKIE_NAME` | `rota_csrf` | Override the CSRF cookie name if your deployment customises it. |
+
+The script automatically logs in (or registers) the synthetic user, enrolls in the first
+available trail, and then runs a dedicated scenario per endpoint. At the end of the run
+it prints a consolidated summary containing:
+
+- Total runtime
+- Total number of HTTP requests
+- Estimated RPS and RPM
+- Network throughput (bytes/second and KiB/second)
+
+The raw metrics are also written to `performance/results.json` so you can archive them or
+feed them into dashboards.
+
+## Repository query benchmark
+
+Run the Python benchmark to measure ORM query performance:
+
+```bash
+python performance/db_benchmark.py --iterations 100 --warmup 10 --json performance/db_results.json
+```
+
+Key options:
+
+| Option | Description |
+| --- | --- |
+| `--iterations` | Number of measured iterations per repository method (default `50`). |
+| `--warmup` | Warm-up iterations per method that are discarded from the results (default `5`). |
+| `--include-writes` | Include benchmarks that perform database writes (disabled by default). |
+| `--user-email` / `--user-password` | Credentials used for the synthetic benchmark user. |
+| `--json` | Path to a JSON file where the script should dump the raw metrics. |
+
+The script ensures the lookup tables contain the expected codes, creates/reuses a test
+user, and then executes every repository method. For each query it reports:
+
+- Average latency per call (ms)
+- Operations per second and per minute
+- Rows processed per second (when applicable)
+
+An aggregated summary at the end shows the combined throughput across all executed
+queries. Use the JSON output to track historical trends or feed the measurements into
+CI pipelines.

--- a/performance/db_benchmark.py
+++ b/performance/db_benchmark.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python
+"""Benchmark database query performance for repository methods."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+from dataclasses import dataclass
+from statistics import mean
+from time import perf_counter
+from typing import Any, Callable, Iterable, Optional
+
+from sqlalchemy import insert, select
+from sqlalchemy.orm import Session
+
+from app.core.db import session_scope
+from app.models.lk_enrollment_status import LkEnrollmentStatus as LkEnrollmentStatusORM
+from app.models.lk_item_type import LkItemType as LkItemTypeORM
+from app.models.lk_progress_status import LkProgressStatus as LkProgressStatusORM
+from app.models.lookups import LkRole, LkSex
+from app.models.trail_items import TrailItems as TrailItemsORM
+from app.models.trail_sections import TrailSections as TrailSectionsORM
+from app.models.trails import Trails as TrailsORM
+from app.models.user_item_progress import UserItemProgress as UserItemProgressORM
+from app.models.user_trails import UserTrails as UserTrailsORM
+from app.models.users import Sex
+from app.models.roles import RolesEnum
+from app.repositories.TrailsRepository import TrailsRepository
+from app.repositories.UserProgressRepository import UserProgressRepository
+from app.repositories.UserTrailsRepository import UserTrailsRepository
+from app.repositories.UsersRepository import UsersRepository
+from app.services.security import hash_password
+
+
+@dataclass
+class BenchmarkContext:
+    trail_id: Optional[int]
+    section_id: Optional[int]
+    item_id: Optional[int]
+    form_item_id: Optional[int]
+    user_id: Optional[int]
+    email: str
+    username: str
+    password: str
+
+
+@dataclass
+class BenchmarkResult:
+    name: str
+    iterations: int
+    total_time: float
+    mean_ms: float
+    ops_per_second: float
+    ops_per_minute: float
+    rows_per_second: float
+    rows_processed: float
+
+
+@dataclass
+class BenchmarkCase:
+    name: str
+    func: Callable[[Session, BenchmarkContext], Any]
+    requires: tuple[str, ...] = ()
+    writes: bool = False
+
+
+LOOKUP_VALUES = {
+    LkSex: ("M", "F", "O", "N"),
+    LkRole: ("Admin", "User", "Manager"),
+    LkItemTypeORM: ("DOC", "VIDEO", "FORM"),
+    LkEnrollmentStatusORM: ("ENROLLED", "IN_PROGRESS", "COMPLETED"),
+    LkProgressStatusORM: ("NOT_STARTED", "IN_PROGRESS", "COMPLETED"),
+}
+
+
+def ensure_lookup_values(session: Session) -> None:
+    for model, codes in LOOKUP_VALUES.items():
+        existing = set(session.execute(select(model.code)).scalars())
+        missing = [code for code in codes if code not in existing]
+        if not missing:
+            continue
+        session.execute(insert(model), [{"code": code} for code in missing])
+    session.commit()
+
+
+def ensure_benchmark_user(session: Session, email: str, password: str) -> User:
+    repo = UsersRepository(session)
+    user = repo.GetUserByEmail(email)
+    if user:
+        return user
+    username = email.split("@")[0]
+    user = repo.CreateUser(
+        email=email,
+        password_hash=hash_password(password),
+        name_for_certificate="Performance Bench",
+        username=username,
+        sex=Sex.Male,
+        role=RolesEnum.User,
+        birthday="1990-01-01",
+    )
+    return user
+
+
+def gather_sample_data(email: str, password: str) -> BenchmarkContext:
+    with session_scope() as session:
+        ensure_lookup_values(session)
+        user = ensure_benchmark_user(session, email, password)
+
+        trail_id = session.scalars(select(TrailsORM.id).limit(1)).first()
+        section_id = None
+        item_id = None
+        form_item_id = None
+
+        if trail_id is not None:
+            section_id = (
+                session.scalars(
+                    select(TrailSectionsORM.id)
+                    .where(TrailSectionsORM.trail_id == trail_id)
+                    .order_by(TrailSectionsORM.order_index, TrailSectionsORM.id)
+                    .limit(1)
+                ).first()
+            )
+            item_id = (
+                session.scalars(
+                    select(TrailItemsORM.id)
+                    .where(TrailItemsORM.trail_id == trail_id)
+                    .order_by(TrailItemsORM.order_index, TrailItemsORM.id)
+                    .limit(1)
+                ).first()
+            )
+            form_item_id = (
+                session.scalars(
+                    select(TrailItemsORM.id)
+                    .join(LkItemTypeORM, TrailItemsORM.type)
+                    .where(TrailItemsORM.trail_id == trail_id, LkItemTypeORM.code == "FORM")
+                    .order_by(TrailItemsORM.order_index, TrailItemsORM.id)
+                    .limit(1)
+                ).first()
+            )
+
+            UserTrailsRepository(session).ensure_enrollment(user.user_id, trail_id)
+
+        return BenchmarkContext(
+            trail_id=trail_id,
+            section_id=section_id,
+            item_id=item_id,
+            form_item_id=form_item_id,
+            user_id=user.user_id,
+            email=email,
+            username=user.username,
+            password=password,
+        )
+
+
+def infer_size(value: Any) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, (list, tuple, set)):
+        if isinstance(value, tuple) and len(value) == 2 and isinstance(value[1], (int, float)):
+            return infer_size(value[0])
+        return float(len(value))
+    if isinstance(value, dict):
+        return float(len(value))
+    if isinstance(value, UserItemProgressORM):
+        return 1.0
+    if isinstance(value, UserTrailsORM):
+        return 1.0
+    return 1.0
+
+
+def run_case(case: BenchmarkCase, iterations: int, warmup: int, ctx: BenchmarkContext) -> BenchmarkResult:
+    durations: list[float] = []
+    rows_processed = 0.0
+    total_iterations = iterations + warmup
+
+    for index in range(total_iterations):
+        with session_scope() as session:
+            start = perf_counter()
+            result = case.func(session, ctx)
+            elapsed = perf_counter() - start
+        if index < warmup:
+            continue
+        durations.append(elapsed)
+        rows_processed += infer_size(result)
+
+    executed = len(durations)
+    total_time = sum(durations)
+    mean_ms = mean(durations) * 1000 if durations else 0.0
+    ops_per_second = executed / total_time if total_time > 0 else 0.0
+    ops_per_minute = ops_per_second * 60.0
+    rows_per_second = rows_processed / total_time if total_time > 0 else 0.0
+
+    return BenchmarkResult(
+        name=case.name,
+        iterations=executed,
+        total_time=total_time,
+        mean_ms=mean_ms,
+        ops_per_second=ops_per_second,
+        ops_per_minute=ops_per_minute,
+        rows_per_second=rows_per_second,
+        rows_processed=rows_processed,
+    )
+
+
+def requirements_met(ctx: BenchmarkContext, requirements: Iterable[str]) -> bool:
+    for key in requirements:
+        if getattr(ctx, key, None) is None:
+            return False
+    return True
+
+
+def create_cases() -> list[BenchmarkCase]:
+    cases: list[BenchmarkCase] = [
+        BenchmarkCase(
+            name="TrailsRepository.list_showcase",
+            func=lambda session, ctx: TrailsRepository(session).list_showcase(limit=6),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_all",
+            func=lambda session, ctx: TrailsRepository(session).list_all(offset=0, limit=10),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.get_trail",
+            func=lambda session, ctx: TrailsRepository(session).get_trail(ctx.trail_id),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_sections",
+            func=lambda session, ctx: TrailsRepository(session).list_sections(ctx.trail_id, offset=0, limit=10),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_section_items",
+            func=lambda session, ctx: TrailsRepository(session).list_section_items(
+                ctx.trail_id,
+                ctx.section_id,
+                offset=0,
+                limit=10,
+            ),
+            requires=("trail_id", "section_id"),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_sections_with_items",
+            func=lambda session, ctx: TrailsRepository(session).list_sections_with_items(ctx.trail_id),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_included_items",
+            func=lambda session, ctx: TrailsRepository(session).list_included_items(ctx.trail_id),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_requirements",
+            func=lambda session, ctx: TrailsRepository(session).list_requirements(ctx.trail_id),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="TrailsRepository.list_audience",
+            func=lambda session, ctx: TrailsRepository(session).list_audience(ctx.trail_id),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="UserTrailsRepository.count_items_in_trail",
+            func=lambda session, ctx: UserTrailsRepository(session).count_items_in_trail(ctx.trail_id),
+            requires=("trail_id",),
+        ),
+        BenchmarkCase(
+            name="UserTrailsRepository.get_progress_for_user",
+            func=lambda session, ctx: UserTrailsRepository(session).get_progress_for_user(ctx.user_id, ctx.trail_id),
+            requires=("user_id", "trail_id"),
+        ),
+        BenchmarkCase(
+            name="UserTrailsRepository.get_items_progress",
+            func=lambda session, ctx: UserTrailsRepository(session).get_items_progress(ctx.user_id, ctx.trail_id),
+            requires=("user_id", "trail_id"),
+        ),
+        BenchmarkCase(
+            name="UserTrailsRepository.get_sections_progress",
+            func=lambda session, ctx: UserTrailsRepository(session).get_sections_progress(ctx.user_id, ctx.trail_id),
+            requires=("user_id", "trail_id"),
+        ),
+        BenchmarkCase(
+            name="UserTrailsRepository.get_progress_map_for_user",
+            func=lambda session, ctx: UserTrailsRepository(session).get_progress_map_for_user(ctx.user_id, [ctx.trail_id], sync=False),
+            requires=("user_id", "trail_id"),
+        ),
+        BenchmarkCase(
+            name="UsersRepository.GetUserByEmail",
+            func=lambda session, ctx: UsersRepository(session).GetUserByEmail(ctx.email),
+            requires=("email",),
+        ),
+        BenchmarkCase(
+            name="UsersRepository.GetUserByUsername",
+            func=lambda session, ctx: UsersRepository(session).GetUserByUsername(ctx.username),
+            requires=("username",),
+        ),
+        BenchmarkCase(
+            name="UsersRepository.GetUserById",
+            func=lambda session, ctx: UsersRepository(session).GetUserById(ctx.user_id),
+            requires=("user_id",),
+        ),
+        BenchmarkCase(
+            name="UsersRepository.ExistsEmail",
+            func=lambda session, ctx: UsersRepository(session).ExistsEmail(ctx.email),
+            requires=("email",),
+        ),
+        BenchmarkCase(
+            name="UsersRepository.ExistsUsername",
+            func=lambda session, ctx: UsersRepository(session).ExistsUsername(ctx.username),
+            requires=("username",),
+        ),
+        BenchmarkCase(
+            name="UserTrailsRepository.ensure_enrollment",
+            func=lambda session, ctx: UserTrailsRepository(session).ensure_enrollment(ctx.user_id, ctx.trail_id),
+            requires=("user_id", "trail_id"),
+            writes=True,
+        ),
+        BenchmarkCase(
+            name="UserProgressRepository.upsert_item_progress",
+            func=lambda session, ctx: UserProgressRepository(session).upsert_item_progress(
+                ctx.user_id,
+                ctx.item_id,
+                status_code="COMPLETED",
+                progress_value=100,
+            ),
+            requires=("user_id", "item_id"),
+            writes=True,
+        ),
+    ]
+
+    return cases
+
+
+def format_number(value: float) -> str:
+    if math.isnan(value) or math.isinf(value):
+        return "n/a"
+    return f"{value:,.2f}"
+
+
+def print_results(results: list[BenchmarkResult]) -> None:
+    if not results:
+        print("No benchmarks executed.")
+        return
+
+    header = f"{'Query':70} {'Ops/s':>12} {'Ops/m':>12} {'Rows/s':>12} {'Mean (ms)':>12}"
+    print(header)
+    print("-" * len(header))
+    for result in results:
+        print(
+            f"{result.name:70} {format_number(result.ops_per_second):>12}"
+            f" {format_number(result.ops_per_minute):>12} {format_number(result.rows_per_second):>12}"
+            f" {format_number(result.mean_ms):>12}"
+        )
+
+    total_iterations = sum(r.iterations for r in results)
+    total_time = sum(r.total_time for r in results)
+    total_rows = sum(r.rows_processed for r in results)
+    overall_ops_sec = total_iterations / total_time if total_time > 0 else 0.0
+    overall_ops_min = overall_ops_sec * 60.0
+    overall_rows_sec = total_rows / total_time if total_time > 0 else 0.0
+
+    print("\nOverall:")
+    print(
+        f"  Executed iterations: {total_iterations}\n"
+        f"  Total runtime: {total_time:.2f}s\n"
+        f"  Aggregate OPS: {format_number(overall_ops_sec)} req/s ({format_number(overall_ops_min)} req/min)\n"
+        f"  Aggregate throughput: {format_number(overall_rows_sec)} rows/s"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark repository query performance.")
+    parser.add_argument("--iterations", type=int, default=50, help="Number of measured iterations per query")
+    parser.add_argument("--warmup", type=int, default=5, help="Warm-up iterations per query")
+    parser.add_argument(
+        "--include-writes",
+        action="store_true",
+        help="Include write-heavy benchmarks (may mutate the database).",
+    )
+    parser.add_argument("--json", dest="json_path", help="Write raw results to the given JSON file")
+    parser.add_argument(
+        "--user-email",
+        default=os.environ.get("PERF_BENCH_EMAIL", "perf-db@example.com"),
+        help="Email used for the synthetic benchmark user.",
+    )
+    parser.add_argument(
+        "--user-password",
+        default=os.environ.get("PERF_BENCH_PASSWORD", "PerfTest@123"),
+        help="Password for the synthetic benchmark user.",
+    )
+    args = parser.parse_args()
+
+    ctx = gather_sample_data(args.user_email, args.user_password)
+    cases = [case for case in create_cases() if args.include_writes or not case.writes]
+
+    results: list[BenchmarkResult] = []
+    for case in cases:
+        if not requirements_met(ctx, case.requires):
+            missing = [req for req in case.requires if getattr(ctx, req, None) is None]
+            print(f"Skipping {case.name} (missing: {', '.join(missing)})")
+            continue
+        result = run_case(case, iterations=args.iterations, warmup=args.warmup, ctx=ctx)
+        results.append(result)
+
+    print_results(results)
+
+    if args.json_path:
+        payload = [result.__dict__ for result in results]
+        with open(args.json_path, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, indent=2)
+        print(f"Raw results written to {args.json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/performance/k6/performance.test.js
+++ b/performance/k6/performance.test.js
@@ -1,0 +1,524 @@
+import http from 'k6/http';
+import { check, fail, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:5000';
+const AUTH_EMAIL = __ENV.AUTH_EMAIL || '';
+const AUTH_PASSWORD = __ENV.AUTH_PASSWORD || 'PerfTest@123';
+const AUTH_USERNAME = __ENV.AUTH_USERNAME || '';
+const DEFAULT_RATE = Number(__ENV.TARGET_RPS || 5);
+const DEFAULT_DURATION = __ENV.TEST_DURATION || '1m';
+const DEFAULT_VUS = Number(__ENV.PRE_ALLOCATED_VUS || 20);
+const ENABLE_WRITE_SCENARIOS = (__ENV.ENABLE_WRITE_SCENARIOS || 'true').toLowerCase() !== 'false';
+const SESSION_COOKIE_NAME = __ENV.SESSION_COOKIE_NAME || 'rota_session';
+const CSRF_COOKIE_NAME = __ENV.CSRF_COOKIE_NAME || 'rota_csrf';
+
+const BASE_SCENARIO = {
+  executor: 'constant-arrival-rate',
+  rate: DEFAULT_RATE,
+  timeUnit: '1s',
+  duration: DEFAULT_DURATION,
+  preAllocatedVUs: DEFAULT_VUS,
+  gracefulStop: '10s',
+};
+
+const endpointLatency = new Trend('endpoint_duration_ms', true);
+const responseBodySize = new Trend('response_body_bytes', true);
+const skipNotices = {};
+
+function scenario(definitionOverrides = {}) {
+  return Object.assign({}, BASE_SCENARIO, definitionOverrides);
+}
+
+const endpointDefinitions = {
+  trails_showcase: {
+    name: 'GET /trails/showcase',
+    method: 'GET',
+    path: () => '/trails/showcase',
+  },
+  trails_list: {
+    name: 'GET /trails',
+    method: 'GET',
+    path: () => '/trails/',
+  },
+  trails_detail: {
+    name: 'GET /trails/:id',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}`,
+    requires: ['dataset.trailId'],
+  },
+  trails_sections: {
+    name: 'GET /trails/:id/sections',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/sections`,
+    requires: ['dataset.trailId'],
+  },
+  trails_section_items: {
+    name: 'GET /trails/:id/sections/:sectionId/items',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/sections/${ctx.dataset.sectionId}/items`,
+    requires: ['dataset.trailId', 'dataset.sectionId'],
+  },
+  trails_sections_with_items: {
+    name: 'GET /trails/:id/sections-with-items',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/sections-with-items`,
+    requires: ['dataset.trailId'],
+  },
+  trails_included_items: {
+    name: 'GET /trails/:id/included-items',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/included-items`,
+    requires: ['dataset.trailId'],
+  },
+  trails_requirements: {
+    name: 'GET /trails/:id/requirements',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/requirements`,
+    requires: ['dataset.trailId'],
+  },
+  trails_audience: {
+    name: 'GET /trails/:id/audience',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/audience`,
+    requires: ['dataset.trailId'],
+  },
+  trails_learn: {
+    name: 'GET /trails/:id/learn',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/learn`,
+    requires: ['dataset.trailId'],
+  },
+  trail_item_detail: {
+    name: 'GET /trails/:id/items/:itemId',
+    method: 'GET',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/items/${ctx.dataset.itemId}`,
+    requires: ['dataset.trailId', 'dataset.itemId'],
+  },
+  auth_login: {
+    name: 'POST /auth/login',
+    method: 'POST',
+    path: () => '/auth/login',
+    headers: { 'Content-Type': 'application/json' },
+    body: (ctx) => JSON.stringify({
+      email: ctx.credentials.email,
+      password: ctx.credentials.password,
+      remember: true,
+    }),
+  },
+  user_trail_enroll: {
+    name: 'POST /user-trails/:trailId/enroll',
+    method: 'POST',
+    path: (ctx) => `/user-trails/${ctx.dataset.trailId}/enroll`,
+    requires: ['dataset.trailId'],
+    authRequired: true,
+    requireCsrf: true,
+  },
+  user_trail_progress: {
+    name: 'GET /user-trails/:trailId/progress',
+    method: 'GET',
+    path: (ctx) => `/user-trails/${ctx.dataset.trailId}/progress`,
+    requires: ['dataset.trailId'],
+    authRequired: true,
+  },
+  user_trail_items_progress: {
+    name: 'GET /user-trails/:trailId/items-progress',
+    method: 'GET',
+    path: (ctx) => `/user-trails/${ctx.dataset.trailId}/items-progress`,
+    requires: ['dataset.trailId'],
+    authRequired: true,
+  },
+  user_trail_sections_progress: {
+    name: 'GET /user-trails/:trailId/sections-progress',
+    method: 'GET',
+    path: (ctx) => `/user-trails/${ctx.dataset.trailId}/sections-progress`,
+    requires: ['dataset.trailId'],
+    authRequired: true,
+  },
+  me_profile: {
+    name: 'GET /me',
+    method: 'GET',
+    path: () => '/me',
+    authRequired: true,
+  },
+  trail_item_progress: {
+    name: 'PUT /trails/:id/items/:itemId/progress',
+    method: 'PUT',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/items/${ctx.dataset.itemId}/progress`,
+    requires: ['dataset.trailId', 'dataset.itemId'],
+    authRequired: true,
+    requireCsrf: true,
+    body: () => JSON.stringify({
+      status: 'COMPLETED',
+      progress_value: 100,
+    }),
+  },
+  trail_form_submission: {
+    name: 'POST /trails/:id/items/:itemId/form-submissions',
+    method: 'POST',
+    path: (ctx) => `/trails/${ctx.dataset.trailId}/items/${ctx.dataset.formItemId}/form-submissions`,
+    requires: ['dataset.trailId', 'dataset.formItemId', 'dataset.formQuestions'],
+    authRequired: true,
+    requireCsrf: true,
+    body: (ctx) => JSON.stringify({
+      duration_seconds: 30,
+      answers: ctx.dataset.formQuestions.map((question) => ({
+        question_id: question.id,
+        selected_option_id: question.firstOptionId,
+        answer_text: question.firstOptionId ? null : 'Benchmark answer',
+      })),
+    }),
+  },
+};
+
+export const options = {
+  scenarios: {
+    trails_showcase: scenario({ exec: 'trails_showcase' }),
+    trails_list: scenario({ exec: 'trails_list' }),
+    trails_detail: scenario({ exec: 'trails_detail' }),
+    trails_sections: scenario({ exec: 'trails_sections' }),
+    trails_section_items: scenario({ exec: 'trails_section_items' }),
+    trails_sections_with_items: scenario({ exec: 'trails_sections_with_items' }),
+    trails_included_items: scenario({ exec: 'trails_included_items' }),
+    trails_requirements: scenario({ exec: 'trails_requirements' }),
+    trails_audience: scenario({ exec: 'trails_audience' }),
+    trails_learn: scenario({ exec: 'trails_learn' }),
+    trail_item_detail: scenario({ exec: 'trail_item_detail' }),
+    auth_login: scenario({ exec: 'auth_login' }),
+    user_trail_enroll: scenario({ exec: 'user_trail_enroll', gracefulStop: '0s' }),
+    user_trail_progress: scenario({ exec: 'user_trail_progress' }),
+    user_trail_items_progress: scenario({ exec: 'user_trail_items_progress' }),
+    user_trail_sections_progress: scenario({ exec: 'user_trail_sections_progress' }),
+    me_profile: scenario({ exec: 'me_profile' }),
+  },
+};
+
+if (ENABLE_WRITE_SCENARIOS) {
+  options.scenarios.trail_item_progress = scenario({ exec: 'trail_item_progress' });
+  options.scenarios.trail_form_submission = scenario({ exec: 'trail_form_submission' });
+}
+
+function resolvePath(obj, path) {
+  return path.split('.').reduce((acc, key) => {
+    if (acc === undefined || acc === null) {
+      return undefined;
+    }
+    return acc[key];
+  }, obj);
+}
+
+function noteSkip(key, reason) {
+  if (skipNotices[key]) {
+    return;
+  }
+  skipNotices[key] = true;
+  console.warn(`Skipping ${endpointDefinitions[key].name}: ${reason}`);
+}
+
+function cookieFromResponse(res, cookieName) {
+  const cookie = res.cookies?.[cookieName];
+  if (!cookie || cookie.length === 0) {
+    return '';
+  }
+  return cookie[cookie.length - 1].value;
+}
+
+function extractAuth(res) {
+  const sessionCookie = cookieFromResponse(res, SESSION_COOKIE_NAME);
+  const csrfCookie = cookieFromResponse(res, CSRF_COOKIE_NAME);
+  const cookieParts = [];
+  if (sessionCookie) {
+    cookieParts.push(`${SESSION_COOKIE_NAME}=${sessionCookie}`);
+  }
+  if (csrfCookie) {
+    cookieParts.push(`${CSRF_COOKIE_NAME}=${csrfCookie}`);
+  }
+  const csrfHeader = res.headers['X-CSRF-Token'] || res.headers['x-csrf-token'] || csrfCookie;
+  return {
+    sessionCookie,
+    csrfCookie,
+    csrfToken: csrfHeader,
+    cookieHeader: cookieParts.join('; '),
+  };
+}
+
+function makeParams(def, ctx) {
+  const params = { tags: { endpoint: def.name } };
+  const headers = { Accept: 'application/json' };
+  if (def.headers) {
+    Object.assign(headers, def.headers);
+  }
+  if (def.authRequired) {
+    if (!ctx.auth || !ctx.auth.cookieHeader) {
+      return null;
+    }
+    headers.Cookie = ctx.auth.cookieHeader;
+    if (def.requireCsrf) {
+      if (!ctx.auth.csrfToken) {
+        return null;
+      }
+      headers['X-CSRF-Token'] = ctx.auth.csrfToken;
+    }
+  }
+  params.headers = headers;
+  return params;
+}
+
+function requestEndpoint(key, ctx) {
+  const def = endpointDefinitions[key];
+  if (!def) {
+    fail(`Unknown endpoint key: ${key}`);
+  }
+  if (def.requires) {
+    for (const requirement of def.requires) {
+      if (!resolvePath(ctx, requirement)) {
+        noteSkip(key, `missing requirement ${requirement}`);
+        return null;
+      }
+    }
+  }
+  const params = makeParams(def, ctx);
+  if (params === null) {
+    noteSkip(key, 'authentication is required but no credentials are available');
+    return null;
+  }
+
+  const pathValue = typeof def.path === 'function' ? def.path(ctx) : def.path;
+  const url = `${BASE_URL}${pathValue}`;
+  const payload = def.body ? def.body(ctx) : null;
+  if (payload && !params.headers['Content-Type']) {
+    params.headers['Content-Type'] = 'application/json';
+  }
+  const response = http.request(def.method, url, payload, params);
+
+  endpointLatency.add(response.timings.duration, { endpoint: def.name });
+  responseBodySize.add(Number(response.body?.length || 0), { endpoint: def.name });
+
+  const ok = check(response, {
+    [`${def.name} < 400`]: (res) => res.status < 400,
+  });
+  if (!ok) {
+    console.error(`${def.name} responded with status ${response.status}`);
+  }
+
+  if (def.authRequired && response.headers['X-CSRF-Token']) {
+    ctx.auth.csrfToken = response.headers['X-CSRF-Token'];
+    if (params.headers.Cookie && !params.headers.Cookie.includes(CSRF_COOKIE_NAME)) {
+      ctx.auth.cookieHeader = `${ctx.auth.cookieHeader}; ${CSRF_COOKIE_NAME}=${ctx.auth.csrfToken}`;
+    }
+  }
+
+  return response;
+}
+
+function ensureUserCredentials() {
+  let email = AUTH_EMAIL;
+  let username = AUTH_USERNAME;
+  const password = AUTH_PASSWORD;
+
+  if (!email) {
+    const stamp = Date.now();
+    email = `perf-${stamp}@example.com`;
+    username = username || `perf_${stamp}`;
+  }
+  if (!username) {
+    username = email.split('@')[0];
+  }
+
+  const payload = JSON.stringify({ email, password, remember: true });
+  const loginRes = http.post(`${BASE_URL}/auth/login`, payload, {
+    headers: { 'Content-Type': 'application/json' },
+    tags: { endpoint: 'POST /auth/login (setup)' },
+  });
+
+  if (loginRes.status === 200) {
+    return { auth: extractAuth(loginRes), credentials: { email, password, username } };
+  }
+
+  if (loginRes.status !== 401) {
+    fail(`Unable to login (${loginRes.status}): ${loginRes.body}`);
+  }
+
+  const registerPayload = JSON.stringify({
+    email,
+    password,
+    name_for_certificate: 'Performance Tester',
+    username,
+    sex: 'M',
+    role: 'User',
+    birthday: '1990-01-01',
+    remember: true,
+  });
+
+  const registerRes = http.post(`${BASE_URL}/auth/register`, registerPayload, {
+    headers: { 'Content-Type': 'application/json' },
+    tags: { endpoint: 'POST /auth/register (setup)' },
+  });
+
+  if (registerRes.status >= 400) {
+    fail(`Unable to register test user (${registerRes.status}): ${registerRes.body}`);
+  }
+
+  return { auth: extractAuth(registerRes), credentials: { email, password, username } };
+}
+
+function hydrateDataset(ctx) {
+  const dataset = {
+    trailId: null,
+    sectionId: null,
+    itemId: null,
+    formItemId: null,
+    formQuestions: null,
+  };
+
+  const params =
+    makeParams({ name: 'dataset bootstrap', authRequired: !!ctx.auth }, ctx) || {
+      headers: { Accept: 'application/json' },
+    };
+
+  const trailsRes = http.get(`${BASE_URL}/trails/`, params);
+  if (trailsRes.status >= 400) {
+    console.warn(`Unable to list trails during setup (${trailsRes.status})`);
+    return dataset;
+  }
+  const trailsJson = trailsRes.json();
+  const firstTrail = trailsJson?.trails?.[0];
+  if (!firstTrail) {
+    console.warn('No trails available to benchmark. Some scenarios will be skipped.');
+    return dataset;
+  }
+
+  dataset.trailId = firstTrail.id;
+
+  const sectionsRes = http.get(`${BASE_URL}/trails/${dataset.trailId}/sections-with-items`, params);
+  if (sectionsRes.status >= 400) {
+    console.warn(`Unable to load sections (${sectionsRes.status})`);
+    return dataset;
+  }
+  const sections = sectionsRes.json();
+  if (Array.isArray(sections) && sections.length > 0) {
+    const firstSection = sections[0];
+    dataset.sectionId = firstSection?.id || null;
+    if (firstSection?.items?.length) {
+      dataset.itemId = firstSection.items[0].id;
+    }
+    for (const section of sections) {
+      if (!section?.items) {
+        continue;
+      }
+      for (const item of section.items) {
+        if (item.type === 'FORM') {
+          dataset.formItemId = item.id;
+          break;
+        }
+      }
+      if (dataset.formItemId) {
+        break;
+      }
+    }
+  }
+
+  if (dataset.trailId && dataset.formItemId) {
+    const detailRes = http.get(
+      `${BASE_URL}/trails/${dataset.trailId}/items/${dataset.formItemId}`,
+      params,
+    );
+    if (detailRes.status < 400) {
+      const detailJson = detailRes.json();
+      const questions = detailJson?.form?.questions || [];
+      dataset.formQuestions = questions.map((question) => ({
+        id: question.id,
+        firstOptionId: question.options?.length ? question.options[0].id : null,
+      }));
+    }
+  }
+
+  return dataset;
+}
+
+export function setup() {
+  const ctx = ensureUserCredentials();
+  ctx.dataset = hydrateDataset(ctx);
+
+  if (ctx.dataset.trailId && ctx.auth && ctx.auth.cookieHeader) {
+    const enrollParams = makeParams(
+      {
+        name: 'POST /user-trails/:trailId/enroll (setup)',
+        method: 'POST',
+        authRequired: true,
+        requireCsrf: true,
+      },
+      ctx,
+    );
+    if (enrollParams) {
+      http.post(`${BASE_URL}/user-trails/${ctx.dataset.trailId}/enroll`, null, enrollParams);
+      sleep(0.1);
+    }
+  }
+
+  return ctx;
+}
+
+function buildExec(name) {
+  return function exec(data) {
+    requestEndpoint(name, data);
+  };
+}
+
+export const trails_showcase = buildExec('trails_showcase');
+export const trails_list = buildExec('trails_list');
+export const trails_detail = buildExec('trails_detail');
+export const trails_sections = buildExec('trails_sections');
+export const trails_section_items = buildExec('trails_section_items');
+export const trails_sections_with_items = buildExec('trails_sections_with_items');
+export const trails_included_items = buildExec('trails_included_items');
+export const trails_requirements = buildExec('trails_requirements');
+export const trails_audience = buildExec('trails_audience');
+export const trails_learn = buildExec('trails_learn');
+export const trail_item_detail = buildExec('trail_item_detail');
+export const auth_login = buildExec('auth_login');
+export const user_trail_enroll = buildExec('user_trail_enroll');
+export const user_trail_progress = buildExec('user_trail_progress');
+export const user_trail_items_progress = buildExec('user_trail_items_progress');
+export const user_trail_sections_progress = buildExec('user_trail_sections_progress');
+export const me_profile = buildExec('me_profile');
+export const trail_item_progress = buildExec('trail_item_progress');
+export const trail_form_submission = buildExec('trail_form_submission');
+
+export function handleSummary(data) {
+  const durationSeconds = data.state?.testRunDurationMs ? data.state.testRunDurationMs / 1000 : 0;
+  const totalRequests = data.metrics?.http_reqs?.count || 0;
+  const rps = durationSeconds ? totalRequests / durationSeconds : 0;
+  const rpm = rps * 60;
+  const throughputBytesPerSecond = durationSeconds
+    ? (data.metrics?.data_received?.sum || 0) / durationSeconds
+    : 0;
+  const throughputKibPerSecond = throughputBytesPerSecond / 1024;
+
+  const summaryLines = [
+    '========== Performance Summary ==========',
+    `Test duration: ${durationSeconds.toFixed(2)}s`,
+    `Total HTTP requests: ${totalRequests}`,
+    `Estimated RPS: ${rps.toFixed(2)}`,
+    `Estimated RPM: ${rpm.toFixed(2)}`,
+    `Throughput: ${throughputBytesPerSecond.toFixed(2)} B/s (${throughputKibPerSecond.toFixed(2)} KiB/s)`,
+    '==========================================',
+  ];
+
+  const summaryText = `${summaryLines.join('\n')}\n`;
+  return {
+    stdout: summaryText,
+    'performance/results.json': JSON.stringify(
+      {
+        duration_seconds: durationSeconds,
+        total_requests: totalRequests,
+        requests_per_second: rps,
+        requests_per_minute: rpm,
+        throughput_bytes_per_second: throughputBytesPerSecond,
+        throughput_kib_per_second: throughputKibPerSecond,
+      },
+      null,
+      2,
+    ),
+  };
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 # tests/conftest.py
 import os
 
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+
 import pytest
 from sqlalchemy import create_engine, event, insert, select
 from sqlalchemy.orm import sessionmaker


### PR DESCRIPTION
## Summary
- replace the pytest-based performance suite with a k6 script that exercises every API endpoint and reports RPS/RPM/throughput metrics
- add a Python utility that benchmarks all repository queries and outputs aggregated throughput data
- document how to run the new benchmarks and configure their environment options

## Testing
- python -m py_compile performance/db_benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68ddda2c2834832ca78cd819d5481b9d